### PR TITLE
Add AlphaDIA v2+ format compatibility to loader

### DIFF
--- a/pydiaid/loader.py
+++ b/pydiaid/loader.py
@@ -87,8 +87,8 @@ class ColumnMapper:
     
     # Define all possible column variants as class attributes
     COLUMN_VARIANTS = {
-        'decoy': ['decoy', 'Decoy', 'is_decoy'],
-        'qvalue': ['QValue', 'Q.Value', 'q_value', 'Q_Value'],
+        'decoy': ['decoy', 'Decoy', 'is_decoy', 'precursor.decoy'],
+        'qvalue': ['QValue', 'Q.Value', 'q_value', 'Q_Value', 'qval', 'precursor.qval'],
         'mobility': [
             'PrecursorIonMobility',
             'IonMobility',
@@ -96,11 +96,41 @@ class ColumnMapper:
             'ion_mobility',
             'IM',
             'Mobility',
-            '1/K0'
+            '1/K0',
+            'mobility_calibrated',
+            'precursor.mobility.observed',
+            'precursor.mobility.library'
         ],
-        'mz': ['PrecursorMz', 'Precursor.Mz', 'Mz', 'PrecursorMZ', 'Calibrated Observed M/Z'],
-        'charge': ['PrecursorCharge', 'Precursor.Charge', 'Charge'],
-        'protein': ['ProteinId', 'ProteinName', 'Protein.Names', 'Protein', 'Protein ID'],
+        'mobility_width': [
+            'base_width_mobility',
+            'precursor.mobility.fwhm',
+            '1/K0 length'
+        ],
+        'mz': [
+            'PrecursorMz',
+            'Precursor.Mz',
+            'Mz',
+            'PrecursorMZ',
+            'Calibrated Observed M/Z',
+            'mz_calibrated',
+            'precursor.mz.observed',
+            'precursor.mz.library'
+        ],
+        'charge': ['PrecursorCharge', 'Precursor.Charge', 'Charge', 'precursor.charge'],
+        'protein': [
+            'ProteinId',
+            'ProteinName',
+            'Protein.Names',
+            'Protein',
+            'Protein ID',
+            'proteins',
+            'pg.proteins'
+        ],
+        'precursor_idx': [
+            'precursor_idx',
+            'precursor.idx',
+            'EG.PrecursorId'
+        ],
         'modified_peptide': [
             'ModifiedPeptideSequence',
             'ModifiedPeptide',
@@ -571,6 +601,7 @@ def __parse_openswath(
     )
 
 
+
 def __parse_alphadia(
     dataframe: pd.DataFrame,
     ptm_list: list,
@@ -579,13 +610,13 @@ def __parse_alphadia(
     """Filters a data frame from AlphaDIA output and parses it to unify
     the column names of the required columns.
 
-    Supports both v1 and v2+ AlphaDIA output formats.
+    Supports both AlphaDIA version < 2.0.0 and version >= 2.0.0 output formats.
 
     Parameters:
     dataframe (pd.DataFrame): imported output file from AlphaDIA.
-        File format: csv/tsv, supports both old and new column naming:
+        File format: csv/tsv/parquet, supports both old and new column naming:
 
-        V1 format (old):
+        AlphaDIA version < 2.0.0:
         'mz_calibrated': calibrated precursor m/z
         'mobility_calibrated': calibrated ion mobility
         'charge': precursor charge state
@@ -595,7 +626,7 @@ def __parse_alphadia(
         'decoy': decoy indicator (0 for targets, 1 for decoys)
         'qval': q-value for false discovery rate control
 
-        V2+ format (new):
+        AlphaDIA version >= 2.0.0:
         'precursor.mz.observed': observed precursor m/z
         'precursor.mobility.observed': observed ion mobility
         'precursor.charge': precursor charge state
@@ -606,98 +637,73 @@ def __parse_alphadia(
         'precursor.qval': q-value for false discovery rate control
 
     ptm_list (list): a list with identifiers used for filtering a specific dataframe column.
-    require_im (bool): if True, requires ion mobility data; if False, makes ion mobility optional.
+    require_im (bool): if True, requires ion mobility data and width columns; if False, makes ion mobility optional.
 
     Returns:
     pd.DataFrame: returns a pre-filtered data frame with unified column names.
     """
-    # Define column mappings for both old and new formats
-    column_mappings = {
-        'mz': {
-            'old': 'mz_calibrated',
-            'new': 'precursor.mz.observed'  # Using observed as suggested by user
-        },
-        'charge': {
-            'old': 'charge',
-            'new': 'precursor.charge'
-        },
-        'proteins': {
-            'old': 'proteins',
-            'new': 'pg.proteins'
-        },
-        'precursor_idx': {
-            'old': 'precursor_idx',
-            'new': 'precursor.idx'
-        },
-        'decoy': {
-            'old': 'decoy',
-            'new': 'precursor.decoy'
-        },
-        'qval': {
-            'old': 'qval',
-            'new': 'precursor.qval'
-        },
-        'mobility': {
-            'old': 'mobility_calibrated',
-            'new': 'precursor.mobility.observed'
-        },
-        'mobility_width': {
-            'old': 'base_width_mobility',
-            'new': 'precursor.mobility.fwhm'
-        }
-    }
-
-    # Detect format and map columns
-    detected_columns = {}
-    format_type = None
-
-    for col_type, mapping in column_mappings.items():
-        if mapping['new'] in dataframe.columns:
-            detected_columns[col_type] = mapping['new']
-            format_type = 'new'
-        elif mapping['old'] in dataframe.columns:
-            detected_columns[col_type] = mapping['old']
-            if format_type is None:
-                format_type = 'old'
-        else:
-            detected_columns[col_type] = None
+    # Use ColumnMapper to detect and map columns
+    mapper = ColumnMapper(dataframe)
 
     # Check required columns exist
-    required_col_types = ['mz', 'charge', 'proteins', 'precursor_idx', 'decoy', 'qval']
-    missing_cols = []
+    required_col_types = ['mz', 'charge', 'protein', 'precursor_idx', 'decoy', 'qvalue']
 
-    for col_type in required_col_types:
-        if detected_columns[col_type] is None:
-            # Show both old and new expected names in error
-            old_name = column_mappings[col_type]['old']
-            new_name = column_mappings[col_type]['new']
-            missing_cols.append(f"{old_name} (v1) or {new_name} (v2+)")
+    try:
+        mapper.validate_required_columns(required_col_types)
+    except ValueError:
+        # Provide more specific error for AlphaDIA context
+        missing_cols = []
+        for col_type in required_col_types:
+            if not mapper.has_column(col_type):
+                variants = mapper.COLUMN_VARIANTS[col_type]
+                # Find AlphaDIA-specific variants for better error message
+                v1_variants = [v for v in variants if '.' not in v and 'precursor.' not in v]
+                v2_variants = [v for v in variants if 'precursor.' in v or 'pg.' in v]
 
-    if missing_cols:
-        raise Exception(f"Required columns missing from AlphaDIA output: {missing_cols}")
+                if v1_variants and v2_variants:
+                    missing_cols.append(f"{v1_variants[0]} (< v2.0.0) or {v2_variants[0]} (>= v2.0.0)")
+                else:
+                    missing_cols.append(f"any of: {', '.join(variants[:3])}")
+
+        if missing_cols:
+            missing_str = '\n  - '.join([''] + missing_cols)
+            raise Exception(f"Required columns missing from AlphaDIA output:{missing_str}")
 
     # Filter for high-quality identifications
     filtered_dataframe = dataframe[
-        (dataframe[detected_columns['decoy']] == 0) &  # Keep only target hits
-        (dataframe[detected_columns['qval']] <= 0.01)  # Filter at 1% FDR
+        (dataframe[mapper.get_column('decoy')] == 0) &  # Keep only target hits
+        (dataframe[mapper.get_column('qvalue')] <= 0.01)  # Filter at 1% FDR
     ]
 
     # Handle ion mobility columns
-    im_col = detected_columns['mobility']
-    im_width_col = detected_columns['mobility_width']
+    im_col = mapper.get_column('mobility')
+    im_width_col = mapper.get_column('mobility_width')
 
-    if require_im and im_col is None:
-        mobility_old = column_mappings['mobility']['old']
-        mobility_new = column_mappings['mobility']['new']
-        raise Exception(f"Ion mobility data required but not found in AlphaDIA output. Expected: {mobility_old} (v1) or {mobility_new} (v2+)")
+    if require_im:
+        # Check both mobility and width columns are present
+        if im_col is None:
+            variants = mapper.COLUMN_VARIANTS['mobility']
+            v1_variants = [v for v in variants if 'mobility_calibrated' in v]
+            v2_variants = [v for v in variants if 'precursor.mobility' in v]
+            raise Exception(f"Ion mobility data required but not found in AlphaDIA output. "
+                          f"Expected: {v1_variants[0] if v1_variants else variants[0]} (< v2.0.0) or "
+                          f"{v2_variants[0] if v2_variants else variants[-1]} (>= v2.0.0)")
+
+        if im_width_col is None:
+            variants = mapper.COLUMN_VARIANTS['mobility_width']
+            v1_variants = [v for v in variants if 'base_width_mobility' in v]
+            v2_variants = [v for v in variants if 'precursor.mobility.fwhm' in v]
+            raise Exception(f"Ion mobility width data required but not found in AlphaDIA output. "
+                          f"Expected: {v1_variants[0] if v1_variants else variants[0]} (< v2.0.0) or "
+                          f"{v2_variants[0] if v2_variants else variants[-1]} (>= v2.0.0)")
 
     return library_loader(
         library=filtered_dataframe,
         ptm_list=ptm_list,
-        mz=detected_columns['mz'],
-        charge=detected_columns['charge'],
-        protein=detected_columns['proteins'],
-        modified_peptide=detected_columns['precursor_idx'],
+        mz=mapper.get_column('mz'),
+        charge=mapper.get_column('charge'),
+        protein=mapper.get_column('protein'),
+        modified_peptide=mapper.get_column('precursor_idx'),
         im=im_col,
         im_length=im_width_col
     )

--- a/pydiaid/loader.py
+++ b/pydiaid/loader.py
@@ -87,8 +87,16 @@ class ColumnMapper:
     
     # Define all possible column variants as class attributes
     COLUMN_VARIANTS = {
-        'decoy': ['decoy', 'Decoy', 'is_decoy', 'precursor.decoy'],
-        'qvalue': ['QValue', 'Q.Value', 'q_value', 'Q_Value', 'qval', 'precursor.qval'],
+        'decoy': [
+            'decoy',  # alphadia < 2
+            'Decoy', 'is_decoy',
+            'precursor.decoy'  # alphadia >= 2
+        ],
+        'qvalue': [
+            'QValue', 'Q.Value', 'q_value', 'Q_Value',
+            'qval',  # alphadia < 2
+            'precursor.qval'  # alphadia >= 2
+        ],
         'mobility': [
             'PrecursorIonMobility',
             'IonMobility',
@@ -97,13 +105,13 @@ class ColumnMapper:
             'IM',
             'Mobility',
             '1/K0',
-            'mobility_calibrated',
-            'precursor.mobility.observed',
-            'precursor.mobility.library'
+            'mobility_calibrated',  # alphadia < 2
+            'precursor.mobility.observed',  # alphadia >= 2
+            'precursor.mobility.library'  # alphadia >= 2
         ],
         'mobility_width': [
-            'base_width_mobility',
-            'precursor.mobility.fwhm',
+            'base_width_mobility',  # alphadia < 2
+            'precursor.mobility.fwhm',  # alphadia >= 2
             '1/K0 length'
         ],
         'mz': [
@@ -112,23 +120,27 @@ class ColumnMapper:
             'Mz',
             'PrecursorMZ',
             'Calibrated Observed M/Z',
-            'mz_calibrated',
-            'precursor.mz.observed',
-            'precursor.mz.library'
+            'mz_calibrated',  # alphadia < 2
+            'precursor.mz.observed',  # alphadia >= 2 (assumption: using observed values will not change window placement much)
+            'precursor.mz.library'  # alphadia >= 2
         ],
-        'charge': ['PrecursorCharge', 'Precursor.Charge', 'Charge', 'precursor.charge'],
+        'charge': [
+            'PrecursorCharge', 'Precursor.Charge',
+            'charge',  # alphadia < 2
+            'precursor.charge'  # alphadia >= 2
+        ],
         'protein': [
             'ProteinId',
             'ProteinName',
             'Protein.Names',
             'Protein',
             'Protein ID',
-            'proteins',
-            'pg.proteins'
+            'proteins',  # alphadia < 2
+            'pg.proteins'  # alphadia >= 2
         ],
         'precursor_idx': [
-            'precursor_idx',
-            'precursor.idx',
+            'precursor_idx',  # alphadia < 2
+            'precursor.idx',  # alphadia >= 2
             'EG.PrecursorId'
         ],
         'modified_peptide': [
@@ -601,6 +613,33 @@ def __parse_openswath(
     )
 
 
+def _raise_alphadia_missing_columns_error(mapper: ColumnMapper, required_col_types: list) -> None:
+    """Generate detailed error message for missing AlphaDIA columns.
+
+    Args:
+        mapper: ColumnMapper instance with detected columns
+        required_col_types: List of required column types
+
+    Raises:
+        Exception: With detailed message showing expected column names for both v1 and v2+ formats
+    """
+    missing_cols = []
+    for col_type in required_col_types:
+        if not mapper.has_column(col_type):
+            variants = mapper.COLUMN_VARIANTS[col_type]
+            # Find AlphaDIA-specific variants for better error message
+            v1_variants = [v for v in variants if '.' not in v and 'precursor.' not in v]
+            v2_variants = [v for v in variants if 'precursor.' in v or 'pg.' in v]
+
+            if v1_variants and v2_variants:
+                missing_cols.append(f"{v1_variants[0]} (< v2.0.0) or {v2_variants[0]} (>= v2.0.0)")
+            else:
+                missing_cols.append(f"any of: {', '.join(variants[:3])}")
+
+    if missing_cols:
+        missing_str = '\n  - '.join([''] + missing_cols)
+        raise Exception(f"Required columns missing from AlphaDIA output:{missing_str}")
+
 
 def __parse_alphadia(
     dataframe: pd.DataFrame,
@@ -651,23 +690,7 @@ def __parse_alphadia(
     try:
         mapper.validate_required_columns(required_col_types)
     except ValueError:
-        # Provide more specific error for AlphaDIA context
-        missing_cols = []
-        for col_type in required_col_types:
-            if not mapper.has_column(col_type):
-                variants = mapper.COLUMN_VARIANTS[col_type]
-                # Find AlphaDIA-specific variants for better error message
-                v1_variants = [v for v in variants if '.' not in v and 'precursor.' not in v]
-                v2_variants = [v for v in variants if 'precursor.' in v or 'pg.' in v]
-
-                if v1_variants and v2_variants:
-                    missing_cols.append(f"{v1_variants[0]} (< v2.0.0) or {v2_variants[0]} (>= v2.0.0)")
-                else:
-                    missing_cols.append(f"any of: {', '.join(variants[:3])}")
-
-        if missing_cols:
-            missing_str = '\n  - '.join([''] + missing_cols)
-            raise Exception(f"Required columns missing from AlphaDIA output:{missing_str}")
+        _raise_alphadia_missing_columns_error(mapper, required_col_types)
 
     # Filter for high-quality identifications
     filtered_dataframe = dataframe[

--- a/pydiaid/loader.py
+++ b/pydiaid/loader.py
@@ -579,9 +579,13 @@ def __parse_alphadia(
     """Filters a data frame from AlphaDIA output and parses it to unify
     the column names of the required columns.
 
+    Supports both v1 and v2+ AlphaDIA output formats.
+
     Parameters:
-    dataframe (pd.DataFrame): imported output file from AlphaDIA. 
-        File format: csv/tsv, required columns:
+    dataframe (pd.DataFrame): imported output file from AlphaDIA.
+        File format: csv/tsv, supports both old and new column naming:
+
+        V1 format (old):
         'mz_calibrated': calibrated precursor m/z
         'mobility_calibrated': calibrated ion mobility
         'charge': precursor charge state
@@ -590,38 +594,110 @@ def __parse_alphadia(
         'base_width_mobility': ion mobility peak width
         'decoy': decoy indicator (0 for targets, 1 for decoys)
         'qval': q-value for false discovery rate control
+
+        V2+ format (new):
+        'precursor.mz.observed': observed precursor m/z
+        'precursor.mobility.observed': observed ion mobility
+        'precursor.charge': precursor charge state
+        'pg.proteins': protein identifiers
+        'precursor.idx': precursor identifier
+        'precursor.mobility.fwhm': ion mobility peak width
+        'precursor.decoy': decoy indicator (0 for targets, 1 for decoys)
+        'precursor.qval': q-value for false discovery rate control
+
     ptm_list (list): a list with identifiers used for filtering a specific dataframe column.
     require_im (bool): if True, requires ion mobility data; if False, makes ion mobility optional.
 
     Returns:
     pd.DataFrame: returns a pre-filtered data frame with unified column names.
     """
-    # Check if required columns exist
-    required_cols = ['mz_calibrated', 'charge', 'proteins', 'precursor_idx', 'decoy', 'qval']
-    missing_cols = [col for col in required_cols if col not in dataframe.columns]
+    # Define column mappings for both old and new formats
+    column_mappings = {
+        'mz': {
+            'old': 'mz_calibrated',
+            'new': 'precursor.mz.observed'  # Using observed as suggested by user
+        },
+        'charge': {
+            'old': 'charge',
+            'new': 'precursor.charge'
+        },
+        'proteins': {
+            'old': 'proteins',
+            'new': 'pg.proteins'
+        },
+        'precursor_idx': {
+            'old': 'precursor_idx',
+            'new': 'precursor.idx'
+        },
+        'decoy': {
+            'old': 'decoy',
+            'new': 'precursor.decoy'
+        },
+        'qval': {
+            'old': 'qval',
+            'new': 'precursor.qval'
+        },
+        'mobility': {
+            'old': 'mobility_calibrated',
+            'new': 'precursor.mobility.observed'
+        },
+        'mobility_width': {
+            'old': 'base_width_mobility',
+            'new': 'precursor.mobility.fwhm'
+        }
+    }
+
+    # Detect format and map columns
+    detected_columns = {}
+    format_type = None
+
+    for col_type, mapping in column_mappings.items():
+        if mapping['new'] in dataframe.columns:
+            detected_columns[col_type] = mapping['new']
+            format_type = 'new'
+        elif mapping['old'] in dataframe.columns:
+            detected_columns[col_type] = mapping['old']
+            if format_type is None:
+                format_type = 'old'
+        else:
+            detected_columns[col_type] = None
+
+    # Check required columns exist
+    required_col_types = ['mz', 'charge', 'proteins', 'precursor_idx', 'decoy', 'qval']
+    missing_cols = []
+
+    for col_type in required_col_types:
+        if detected_columns[col_type] is None:
+            # Show both old and new expected names in error
+            old_name = column_mappings[col_type]['old']
+            new_name = column_mappings[col_type]['new']
+            missing_cols.append(f"{old_name} (v1) or {new_name} (v2+)")
+
     if missing_cols:
         raise Exception(f"Required columns missing from AlphaDIA output: {missing_cols}")
-    
+
     # Filter for high-quality identifications
     filtered_dataframe = dataframe[
-        (dataframe['decoy'] == 0) &  # Keep only target hits
-        (dataframe['qval'] <= 0.01)  # Filter at 1% FDR
+        (dataframe[detected_columns['decoy']] == 0) &  # Keep only target hits
+        (dataframe[detected_columns['qval']] <= 0.01)  # Filter at 1% FDR
     ]
 
-    # Check if IM columns exist
-    im_col = 'mobility_calibrated' if 'mobility_calibrated' in filtered_dataframe.columns else None
-    im_width_col = 'base_width_mobility' if 'base_width_mobility' in filtered_dataframe.columns else None
-    
-    if require_im and (im_col is None or im_width_col is None):
-        raise Exception("Ion mobility data required but not found in AlphaDIA output")
+    # Handle ion mobility columns
+    im_col = detected_columns['mobility']
+    im_width_col = detected_columns['mobility_width']
+
+    if require_im and im_col is None:
+        mobility_old = column_mappings['mobility']['old']
+        mobility_new = column_mappings['mobility']['new']
+        raise Exception(f"Ion mobility data required but not found in AlphaDIA output. Expected: {mobility_old} (v1) or {mobility_new} (v2+)")
 
     return library_loader(
         library=filtered_dataframe,
         ptm_list=ptm_list,
-        mz='mz_calibrated',
-        charge='charge',
-        protein='proteins',
-        modified_peptide='precursor_idx',
+        mz=detected_columns['mz'],
+        charge=detected_columns['charge'],
+        protein=detected_columns['proteins'],
+        modified_peptide=detected_columns['precursor_idx'],
         im=im_col,
         im_length=im_width_col
     )


### PR DESCRIPTION
- Support both v1 and v2+ AlphaDIA column naming conventions
- Implement automatic format detection based on available columns
- Add column mappings for new dot notation format (e.g., precursor.mz.observed)
- Maintain full backward compatibility with existing v1 format files
- Enhance error messages to show both old and new expected column names

Resolves compatibility issues with AlphaDIA v2.0.0+ breaking changes while preserving support for legacy v1 format datasets.